### PR TITLE
[FIX/#84] 작성자 관련 필드명 변경

### DIFF
--- a/src/main/java/com/backend/devfordev/dto/CommunityResponse.java
+++ b/src/main/java/com/backend/devfordev/dto/CommunityResponse.java
@@ -21,7 +21,7 @@ public class CommunityResponse {
         @Schema(description = "커뮤니티 내용", example = "커뮤니티 내용 부분입니다.")
         String communityContent;
         @Schema(description = "작성자 ID", example = "1")
-        Long member;
+        Long writer;
         @Schema(description = "커뮤니티 답변 동의 여부", example = "true")
         Boolean isComment;
         @Schema(description = "작성시간", example = "2024-11-19T00:52:47.534061")
@@ -58,7 +58,7 @@ public class CommunityResponse {
         @Schema(description = "커뮤니티 내용", example = "커뮤니티 내용 부분입니다.")
         String communityContent;
 
-        MemberInfo member;
+        MemberInfo writer;
         @Schema(description = "작성시간", example = "2024-11-19T00:52:47.534061")
         LocalDateTime createdAt;
         @Schema(description = "답변수", example = "0")
@@ -85,7 +85,7 @@ public class CommunityResponse {
         String communityContent;
         @Schema(description = "커뮤니티 답변 동의 여부", example = "true")
         Boolean isComment;
-        MemberInfo member;
+        MemberInfo writer;
         @Schema(description = "작성시간", example = "2024-11-19T00:52:47.534061")
         LocalDateTime createdAt;
         @Schema(description = "답변수", example = "0")
@@ -120,7 +120,7 @@ public class CommunityResponse {
         @Schema(description = "커뮤니티 내용", example = "커뮤니티 내용 부분입니다.")
         String communityContent;
         @Schema(description = "작성자 ID", example = "1")
-        Long member;
+        Long writer;
         @Schema(description = "커뮤니티 답변 동의 여부", example = "true")
         Boolean isComment;
         @Schema(description = "작성시간", example = "2024-11-19T00:52:47.534061")

--- a/src/main/java/com/backend/devfordev/dto/PortfolioResponse.java
+++ b/src/main/java/com/backend/devfordev/dto/PortfolioResponse.java
@@ -20,7 +20,7 @@ public class PortfolioResponse {
         @Schema(description = "커뮤니티 ID", example = "1")
         Long id;
         @Schema(description = "작성자 ID", example = "1")
-        Long member;
+        Long writer;
         @Schema(description = "포트폴리오 제목", example = "김민지의 포트폴리오~~")
         String portTitle;
         @Schema(description = "포트폴리오 내용", example = "포트폴리오 내용~~")
@@ -316,7 +316,7 @@ public class PortfolioResponse {
         private List<String> tags;
         @Schema(description = "포트폴리오 이미지 url", example = "이미지url")
         String portImageUrl;
-        CommunityResponse.MemberInfo member;
+        CommunityResponse.MemberInfo writer;
         @Schema(description = "작성시간", example = "2024-11-19T00:52:47.534061")
         LocalDateTime createdAt;
         @Schema(description = "답변수", example = "0")

--- a/src/main/java/com/backend/devfordev/dto/TeamResponse.java
+++ b/src/main/java/com/backend/devfordev/dto/TeamResponse.java
@@ -43,7 +43,7 @@ public class TeamResponse {
     public static class TeamListResponse {
         @Schema(description = "팀 모집 id", example = "1")
         Long id;
-        CommunityResponse.MemberInfo member;
+        CommunityResponse.MemberInfo writer;
         @Schema(description = "팀 모집 제목", example = "팀 모집 제목입니다.")
         String teamTitle;
         @Schema(description = "팀 모집 내용", example = "팀 모집 내용입니다.")
@@ -78,7 +78,7 @@ public class TeamResponse {
     public static class TeamDetailResponse {
         @Schema(description = "팀 모집 id", example = "1")
         Long id;
-        CommunityResponse.MemberInfo member;
+        CommunityResponse.MemberInfo writer;
         @Schema(description = "팀 모집 제목", example = "팀 모집 제목입니다.")
         String teamTitle;
         @Schema(description = "팀 모집 내용", example = "팀 모집 내용입니다.")


### PR DESCRIPTION
## 개발내용
- 작성자를 의미하는 member 필드명에 혼동
- writer로 전체 필드명 변경

## 이슈번호
#84 

## 개발내용
like this
<img width="599" alt="스크린샷 2024-12-04 오전 2 58 18" src="https://github.com/user-attachments/assets/0c315671-5de1-44c8-a759-f92a5c26e89b">
